### PR TITLE
[main] Update app baselines package version. New value: 24.3.21177.0 (+ 1 more update(s))

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,10 +1,10 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "25.0.20240617.3",
+    "Version": "25.0.20240624.2",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "24.3.20901.0",
+    "Version": "24.3.21177.0",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
This PR contains the following changes:
- Update app baselines package version. New value: 24.3.21177.0
- Update translation package version. New value: 25.0.20240624.2

Fixes AB#420000.